### PR TITLE
Remove files from the gem build

### DIFF
--- a/github-app-auth.gemspec
+++ b/github-app-auth.gemspec
@@ -16,11 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "#{spec.homepage}"
   spec.metadata["changelog_uri"] = "#{spec.homepage}"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files = Dir.glob("lib/**/*") + %w[CODE_OF_CONDUCT.md LICENSE.txt README.md]
   spec.require_paths = ["lib"]
   spec.add_dependency "jwt", "~> 2.7"
   spec.add_dependency "octokit", "~> 6.1"


### PR DESCRIPTION
We don't need a bunch of files that are being picked up in the gem build.