### PR TITLE
Remove deprecated app_installation_* methods

### DIFF
--- a/lib/github_app_auth/app_installation.rb
+++ b/lib/github_app_auth/app_installation.rb
@@ -4,17 +4,6 @@ module GitHub
   module App
     # GitHub App Installation Authentication
     module Auth
-      # legacy support because original only supported repo
-      def app_installation_client(repo, options = {})
-        puts "DEPRECATED: app_installation_client will be removed in v0.4.0, use repository_installation_client instead"
-        client(bearer_token: app_installation_token(repo, options))
-      end
-
-      def app_installation_token(repo, options = {})
-        puts "DEPRECATED: app_installation_token will be removed in v0.4.0, use repository_installation_token instead"
-        installation_token(:repository, repo, options)
-      end
-
       def organization_installation_client(org, options = {})
         client(bearer_token: organization_installation_token(org, options))
       end

--- a/spec/github/app/auth/app_installation_spec.rb
+++ b/spec/github/app/auth/app_installation_spec.rb
@@ -11,53 +11,6 @@ RSpec.describe GitHub::App::Auth do
   let(:token) { "test-token" }
   let(:user) { "test-user" }
 
-  describe ".app_installation_client" do
-    it "returns an Octokit::Client authorized to an app installation" do
-      expect(subject).to receive(:app_installation_token)
-                     .with(repo, {})
-                     .and_return("test-token")
-      expect(subject.app_installation_client(repo)).to be_kind_of(Octokit::Client)
-    end
-
-    it "returns an Octokit::Client authorized to an app installation" do
-      expect(subject).to receive(:app_installation_token)
-                     .with(repo, {})
-                     .and_return("test-token")
-      expected_output = "DEPRECATED: app_installation_client will be removed in v0.4.0, use repository_installation_client instead\n"
-      expect { subject.app_installation_client(repo) }.to output(expected_output).to_stdout
-    end
-  end
-
-  describe ".app_installation_token" do
-    it "returns a JWT token for for an app" do
-      expect(subject).to receive(:app_client)
-                     .and_return(github_client)
-      expect(github_client).to receive(:find_repository_installation)
-                           .with(repo)
-                           .and_return(id: installation_id)
-      expect(github_client).to receive(:create_app_installation_access_token)
-                           .with(installation_id)
-                           .and_return(token: token)
-      expect(subject.app_installation_token(repo)).to eq(token)
-    end
-
-    it "outputs a deprecation notice" do
-      expect(subject).to receive(:app_client)
-                     .and_return(github_client)
-      expect(github_client).to receive(:find_repository_installation)
-                           .with(repo)
-                           .and_return(id: installation_id)
-      expect(github_client).to receive(:create_app_installation_access_token)
-                           .with(installation_id)
-                           .and_return(token: token)
-      expected_output = [
-        "DEPRECATED: app_installation_client will be removed in v0.4.0, use repository_installation_client instead",
-        "DEPRECATED: app_installation_token will be removed in v0.4.0, use repository_installation_token instead\n"
-      ].join("\n")
-      expect { subject.app_installation_client(repo) }.to output(expected_output).to_stdout
-    end
-  end
-
   describe ".organization_installation_client" do
     it "returns an Octokit::Client authorized to an organization installation" do
       expect(subject).to receive(:organization_installation_token)

--- a/spec/github/app/auth_spec.rb
+++ b/spec/github/app/auth_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe GitHub::App::Auth do
   it "provides a class that includes the module's methods" do
     auth = GitHub::App::Auth::AuthClass.new
     expect(auth).to be_kind_of(GitHub::App::Auth::AuthClass)
-    expect(auth.public_methods).to include(:app_installation_client)
     expected_methods = [
       :app_token,
       :app_client,
-      :app_installation_token,
-      :app_installation_client
+      :organization_installation_token,
+      :organization_installation_client,
+      :repository_installation_token,
+      :repository_installation_client,
+      :user_installation_token,
+      :user_installation_client
     ]
     expected_methods.each do |method|
       expect(auth.public_methods).to include(method)


### PR DESCRIPTION
Remove the deprecated `app_installation_*` methods since they've been replaced by methods for the specific types (org, repo, and user) of installations.