### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+  - remove deprecated app_* methods that were only repository installations
+  - change require to 'github_app_auth' when adding linter
+
 ## 0.3.0
   - deprecates app_* methods that were only repository installations
   - adds methods to do organization, repository, and user installations

--- a/lib/github_app_auth/version.rb
+++ b/lib/github_app_auth/version.rb
@@ -3,7 +3,7 @@
 module GitHub
   module App
     module Auth
-      VERSION = "0.3.0"
+      VERSION = "0.4.0"
     end
   end
 end


### PR DESCRIPTION
Release 0.4.0 with the following changes:
- remove deprecated app_* methods that were only repository installations
- change require to 'github_app_auth' when adding linter