### PR TITLE
Loosen octokit dependency

### DIFF
--- a/github-app-auth.gemspec
+++ b/github-app-auth.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob("lib/**/*") + %w[CHANGELOG.md CODE_OF_CONDUCT.md LICENSE.txt README.md]
   spec.require_paths = ["lib"]
   spec.add_dependency "jwt", "~> 2.7"
-  spec.add_dependency "octokit", "~> 6.1"
+  spec.add_dependency "octokit", ">= 6.1"
   spec.add_dependency "openssl", "~> 3.1"
 end


### PR DESCRIPTION
Do you mind loosening this dependency a bit? There is code I want in octokit 7. It looks like the main thing you're counting on is that `Octokit::Client.new` accepts `bearer_token`, and [it has for 7 years at this point.](https://github.com/octokit/octokit.rb/blame/main/lib/octokit/configurable.rb#L57)