### PR TITLE
Update app_installation.rb to allow to pass options to the github client

### DIFF
--- a/lib/github_app_auth/app_installation.rb
+++ b/lib/github_app_auth/app_installation.rb
@@ -5,7 +5,7 @@ module GitHub
     # GitHub App Installation Authentication
     module Auth
       def organization_installation_client(org, options = {})
-        client(bearer_token: organization_installation_token(org, options))
+        client(bearer_token: organization_installation_token(org, options), **options)
       end
 
       def organization_installation_token(org, options = {})

--- a/lib/github_app_auth/version.rb
+++ b/lib/github_app_auth/version.rb
@@ -3,7 +3,7 @@
 module GitHub
   module App
     module Auth
-      VERSION = "0.4.2"
+      VERSION = "0.4.3"
     end
   end
 end


### PR DESCRIPTION
I'd like to use the auto-pagination. Something like:

```
 organization_installation_client("MY_ORG", auto_paginate: true)
```

Currently, the options are not passed to the octokit client